### PR TITLE
Localize item tags for EMI plugin

### DIFF
--- a/resources/assets/architects_palette/lang/de_de.json
+++ b/resources/assets/architects_palette/lang/de_de.json
@@ -242,7 +242,7 @@
   "block.architects_palette.shocked_acacia_totem": "Schockierter Akazientotem",
   "block.architects_palette.acacia_totem_wing": "Akazientotemflügel",
 
-  "architects_palette.advancement.root": "Architect's Palette", //it's a name im not gonna translate it
+  "architects_palette.advancement.root": "Architect's Palette",
   "architects_palette.advancement.root.desc": "Zeit etwas neues mit etwas neuem zu bauen.",
   "architects_palette.advancement.totem_carving": "Wisch dir das Grinsen aus deinen Gesicht",
   "architects_palette.advancement.totem_carving.desc": "Schnitze einen Akazientotem in einen anderen mithilfe einer Axt um.",

--- a/resources/assets/architects_palette/lang/en_us.json
+++ b/resources/assets/architects_palette/lang/en_us.json
@@ -11,6 +11,8 @@
 
   "__comment__": "These strings are used in the JEI/REI plugins.",
   "architects_palette.info.warping_recipe_title": "Warping",
+  "__comment__": "EMI implementation detail. Should be the same string as above.",
+  "emi.category.architects_palette.warping": "Warping",
   "__comment__": "The %s in the string is replaced with the corresponding dimension when displayed in game",
   "architects_palette.info.warping_toss_description": "Toss into a portal that leads to %s.",
   "__comment__": "Modders can add support to the preview by adding something like this to their lang files, under the architects_palette namespace",
@@ -110,6 +112,8 @@
   "block.architects_palette.olivestone_tile_stairs": "Olivestone Tile Stairs",
   "block.architects_palette.illuminated_olivestone": "Illuminated Olivestone",
   "block.architects_palette.chiseled_olivestone": "Chiseled Olivestone",
+  "tag.architects_palette.olivestone": "Olivestone",
+  "tag.architects_palette.olivestone_slabs": "Olivestone Slabs",
 
   "block.architects_palette.algal_bricks": "Algal Bricks",
   "block.architects_palette.cracked_algal_bricks": "Cracked Algal Bricks",
@@ -226,6 +230,7 @@
   "block.architects_palette.withered_osseous_brick_vertical_slab": "Withered Osseous Brick Vertical Slab",
   "block.architects_palette.wither_lamp": "Wither Lamp",
   "item.architects_palette.withered_bone": "Withered Bone",
+  "tag.c.withered_bones": "Withered Bones",
 
   "block.architects_palette.entwine_block": "Entwine",
   "block.architects_palette.chiseled_entwine": "Chiseled Entwine",
@@ -288,6 +293,7 @@
   "block.architects_palette.twisted_leaves": "Twisted Leaves",
   "block.architects_palette.twisted_sapling": "Twisted Sapling",
   "block.architects_palette.potted_twisted_sapling": "Potted Twisted Sapling",
+  "tag.architects_palette.twisted_logs": "Twisted Logs",
 
   "block.architects_palette.basalt_tiles": "Basalt Tiles",
   "block.architects_palette.basalt_tile_wall": "Basalt Tile Wall",


### PR DESCRIPTION
This PR does two things
1) Duplicates the Warping recipe title for EMI support (their lang key for this is mega hardcoded right now, sorry)
2) Adds en_us localizations for item tags  

Merging of this PR will allow me to un-draft my EMI plugin PR for the fabric port.  
Seen here: https://github.com/Slomaxonical-907/Architects-Palette-Fabric/pull/19

Also, while looking through the files, I found a syntax error in de_de.json that would've prevented it from loading. Bonus fix.